### PR TITLE
Initial test coverage

### DIFF
--- a/roosevelt/test/channels/redis_channel_test.exs
+++ b/roosevelt/test/channels/redis_channel_test.exs
@@ -1,0 +1,16 @@
+defmodule Roosevelt.RedisChannelTest do
+  use Roosevelt.ChannelCase
+
+  setup do
+    @endpoint = Roosevelt.Endpoint
+    {:ok, _, socket} =
+      socket("user:id", %{})
+      |> subscribe_and_join(Roosevelt.RedisChannel, "redis:listen", %{})
+    {:ok, socket: socket}
+  end
+
+  test "receives a broadcast when new tweet is added" do
+    Roosevelt.Fixtures.publish_tweet(%{id: 4, popularity: 1})
+    assert_broadcast "new:response", %{tweet: _, index: _}
+  end
+end

--- a/roosevelt/test/controllers/page_controller_test.exs
+++ b/roosevelt/test/controllers/page_controller_test.exs
@@ -1,8 +1,0 @@
-defmodule Roosevelt.PageControllerTest do
-  use Roosevelt.ConnCase
-
-  test "GET /", %{conn: conn} do
-    conn = get conn, "/"
-    assert html_response(conn, 200) =~ "Welcome to Phoenix!"
-  end
-end

--- a/roosevelt/test/models/tweet_list_test.exs
+++ b/roosevelt/test/models/tweet_list_test.exs
@@ -1,0 +1,29 @@
+defmodule Roosevelt.TweetListTest do
+  require IEx
+  use Roosevelt.ModelCase, async: false
+
+  setup_all do
+    {:ok,
+     popular_tweet: Roosevelt.Fixtures.tweet_json(%{popularity: 10, id: 2}),
+     unpopular_tweet: Roosevelt.Fixtures.tweet_json(%{popularity: 0, id: 3}),
+     initial_state: [Poison.Parser.parse!(Roosevelt.Fixtures.tweet_json(%{popularity: 5, id: 1}))]}
+  end
+
+  test "updates internal list when receiving new tweets" do
+     Roosevelt.Fixtures.publish_tweet %{popularity: 1, id: 5}
+     # There's a race condition in that the assertion can execute before
+     # the pubsub callback in TweetList. This sleep is a code smell, and
+     # ideally Exredis should be mocked out of the tests entirely, anyways.
+     :timer.sleep(1)
+     assert Enum.member?(Enum.map(Roosevelt.TweetList.tweet_list, fn x -> x["id"] end), "5")
+  end
+
+  test "keeps tweets sorted descending by priority", context do
+    {:noreply, state_with_two_tweets} = Roosevelt.TweetList.handle_cast(context[:popular_tweet], context[:initial_state])
+    IEx.pry
+    assert hd(state_with_two_tweets)["id"] == "2"
+
+    {:noreply, state_with_three_tweets} = Roosevelt.TweetList.handle_cast(context[:unpopular_tweet], state_with_two_tweets)
+    assert List.last(state_with_three_tweets)["id"] == "3"
+  end
+end

--- a/roosevelt/test/support/fixtures.ex
+++ b/roosevelt/test/support/fixtures.ex
@@ -1,0 +1,12 @@
+defmodule Roosevelt.Fixtures do
+
+  def publish_tweet(options) do
+    Exredis.Api.publish "storm_tweet_feed", tweet_json(options)
+  end
+
+  def tweet_json(%{popularity: popularity, id: id}) do
+    """
+    {\"popularity\":\"#{popularity}\",\"html\":\"<blockquote class=\\\"twitter-tweet\\\" data-conversation=\\\"none\\\" data-cards=\\\"hidden\\\" data-width=\\\"220\\\"><p lang=\\\"en\\\" dir=\\\"ltr\\\">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse enim nibh, tincidunt at pretium et, congue et mi. Etiam at dolor non leo imperdiet rutrum nec a quam.</p>&mdash; jack (@jack) <a href=\\\"https://twitter.com/jack/status/20\\\">April 8, 2016</a></blockquote>\\n\",\"id\":\"#{id}\"}
+    """
+  end
+end


### PR DESCRIPTION
This PR has a handful of tests around the logic for receiving tweets from Redis, broadcasting to channels, and keeping them sorted by priority. I wrestled a lot trying to test our stateful Genserver with Elixir's inherently concurrent and randomized test execution, so there are some not-so-great patterns here until I up my game.
